### PR TITLE
test(multiton): fix testing on static_attributes for python < 3.13

### DIFF
--- a/src/deluxe/_static.py
+++ b/src/deluxe/_static.py
@@ -230,6 +230,7 @@ class StaticType(FrozenType, _ProtocolMeta):
                     co_qualname=qualname,
                 ),
                 globals=func.__globals__,
+                closure=(),
             )
             func.__module__ = module
             if is_abstract:

--- a/src/deluxe/_static.py
+++ b/src/deluxe/_static.py
@@ -230,7 +230,7 @@ class StaticType(FrozenType, _ProtocolMeta):
                     co_qualname=qualname,
                 ),
                 globals=func.__globals__,
-                closure=(),
+                closure=func.__closure__,
             )
             func.__module__ = module
             if is_abstract:

--- a/tests/multiton_test.py
+++ b/tests/multiton_test.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import gc
+import sys
 from copy import copy, deepcopy
 from typing import Any, final
 
@@ -960,6 +961,10 @@ def test_slots_preserves_existing_weakref():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 13),
+    reason="__static_attributes__ is only set by the compiler in Python 3.13+",
+)
 def test_match_args_defaults_to_static_attributes():
     """When __match_args__ is not defined, it defaults to __static_attributes__."""
 

--- a/tests/static_type_test.py
+++ b/tests/static_type_test.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Protocol
+from typing import Any, Literal, Protocol, TYPE_CHECKING
 
 import pytest
 from deluxe.types import StaticType
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class A: ...
@@ -133,3 +136,27 @@ def test_slots_merge():
         __slots__: set[str] = {"y"}
 
     assert _.__slots__ == {"x", "y"}
+
+
+def test_borrow_closure_function():
+    """Borrowing a class with a closure function should not raise TypeError.
+
+    Regression test: Python 3.11+ requires a proper closure tuple (not None)
+    when creating FunctionType from a code object with free variables.
+    """
+
+    def _make_closer() -> Callable[..., Literal[42]]:
+        value = 42
+
+        def closer(_self: Any):
+            return value
+
+        return closer
+
+    class Source(metaclass=StaticType):
+        method: Any = _make_closer()  # type: ignore[assignment]
+
+    class Derived(Source): ...
+
+    assert Derived().method() == 42
+    assert Source().method() == 42


### PR DESCRIPTION
## Fix `StaticType` closure forwarding and multiton test compatibility

### Problem

When a class using `StaticType` as its metaclass borrows a method that originates from a closure (a nested function that captures variables from an outer scope), calling that method raises a `TypeError` on Python 3.11+. This happens because `FunctionType` construction requires a proper `closure` tuple (not `None`) when the code object has free variables — but the closure was not being forwarded.

Additionally, a multiton test (`test_match_args_defaults_to_static_attributes`) was failing on Python < 3.13 because `__static_attributes__` is only populated by the compiler starting from Python 3.13.

### Changes

1. **`src/deluxe/_static.py`** — In `StaticType`, when creating a borrowed `FunctionType` from a code object that has free variables, the original function's `__closure__` is now passed through. This ensures closures are properly captured on the borrowed copy.

2. **`tests/multiton_test.py`** — Added `sys.version_info < (3, 13)` skip guard on `test_match_args_defaults_to_static_attributes` since the feature it depends on (`__static_attributes__`) is only set by the compiler in Python 3.13+.

3. **`tests/static_type_test.py`** — Added `test_borrow_closure_function` to verify that borrowing a class whose methods come from closures works correctly on all supported Python versions